### PR TITLE
bulk upload questions via XLSX

### DIFF
--- a/Source/Microsoft.Teams.Apps.FAQPlusPlus/Bots/FaqPlusPlusBot.cs
+++ b/Source/Microsoft.Teams.Apps.FAQPlusPlus/Bots/FaqPlusPlusBot.cs
@@ -1302,7 +1302,11 @@ namespace Microsoft.Teams.Apps.FAQPlusPlus.Bots
         private bool IsActivityFromExpectedTenant(ITurnContext turnContext)
         {
 #if DEBUG
-            return true;
+            // only check Tenant when in Teams
+            if (turnContext.Activity.ChannelId != Channels.Msteams)
+            {
+                return true;
+            }
 #endif
             return turnContext.Activity.Conversation.TenantId == this.options.TenantId;
         }

--- a/Source/Microsoft.Teams.Apps.FAQPlusPlus/Helpers/CsvHelper.cs
+++ b/Source/Microsoft.Teams.Apps.FAQPlusPlus/Helpers/CsvHelper.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Text.RegularExpressions;
 
 namespace Microsoft.Teams.Apps.FAQPlusPlus.Helpers
@@ -33,6 +34,38 @@ namespace Microsoft.Teams.Apps.FAQPlusPlus.Helpers
 
                 this.Add(values);
             }
+        }
+
+        public static IList<AnswerItem> AnswerListFromCsv(string fileContent)
+        {
+            CSVHelper csv = new CSVHelper(fileContent, ",", true);
+            var answers = from string[] line in csv
+                          select new AnswerItem
+                          {
+                              Question = line[0],
+                              Answer = null,
+                              Metadata = line[2],
+                          };
+            return answers.ToList();
+        }
+
+        public static byte[] CsvFromQuestions(IList<AnswerItem> questions)
+        {
+            var csvOut = new StringBuilder();
+            var header = "Question,Answer,Metadata";
+            csvOut.AppendLine(header);
+            foreach (var answer in questions)
+            {
+                var q = answer.Question;
+                var a = answer.Answer;
+                var m = answer.Metadata;
+                var qapair = string.Format("{0},{1},{2}", q, a, m);
+                csvOut.AppendLine(qapair);
+            }
+
+            var csvString = csvOut.ToString();
+            var bytes = UTF8Encoding.UTF8.GetBytes(csvString);
+            return bytes;
         }
     }
 }

--- a/Source/Microsoft.Teams.Apps.FAQPlusPlus/Helpers/QnaHelper.cs
+++ b/Source/Microsoft.Teams.Apps.FAQPlusPlus/Helpers/QnaHelper.cs
@@ -172,6 +172,9 @@ namespace Microsoft.Teams.Apps.FAQPlusPlus.Helpers
 
         [JsonProperty("question")]
         public string Question { get; set; }
+
+        [JsonProperty("metadata")]
+        public string Metadata { get; set; }
     }
 
     /// <summary>

--- a/Source/Microsoft.Teams.Apps.FAQPlusPlus/Helpers/XlsxHelper.cs
+++ b/Source/Microsoft.Teams.Apps.FAQPlusPlus/Helpers/XlsxHelper.cs
@@ -1,0 +1,248 @@
+﻿using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Microsoft.Teams.Apps.FAQPlusPlus.Helpers
+{
+    public static class XlsxHelper
+    {
+        /// <summary>
+        /// Reads an Excel spreadsheet from stream and returns the list of questions it contains. The
+        /// spreadsheet must contain three columns (Question, Answer, and Metadata) and the first
+        /// row is ignored as a header row.
+        /// </summary>
+        /// <param name="stream">a stream which will bet written to</param>
+        /// <returns>A list of question/answer pairs</returns>
+        public static List<AnswerItem> QuestionsFromXlsx(Stream stream)
+        {
+            using (SpreadsheetDocument spreadSheet = SpreadsheetDocument.Open(stream, false))
+            {
+                List<AnswerItem> questions;
+                WorkbookPart workbookPart = spreadSheet.WorkbookPart;
+                WorksheetPart worksheetPart = workbookPart.WorksheetParts.First();
+                SheetData sheetData = worksheetPart.Worksheet.Elements<SheetData>().First();
+
+                // shared strings table.
+                var stringTable =
+                    workbookPart.GetPartsOfType<SharedStringTablePart>()
+                    .FirstOrDefault();
+
+                questions = new List<AnswerItem>();
+
+                int rowCount = sheetData.Elements<Row>().Count();
+                for (int i = 1; i < rowCount; i++)
+                {
+                    uint rowIdx = (uint)i + 1;   // excel rows are 1-based
+
+                    var questionCell = GetCell(worksheetPart.Worksheet, "A", rowIdx);
+                    var answerCell = GetCell(worksheetPart.Worksheet, "B", rowIdx);
+                    var metadataCell = GetCell(worksheetPart.Worksheet, "C", rowIdx);
+
+                    AnswerItem item = new AnswerItem
+                    {
+                        Question = GetTextFromCell(questionCell, stringTable),
+                        Answer = GetTextFromCell(answerCell, stringTable),
+                        Metadata = GetTextFromCell(metadataCell, stringTable),
+                    };
+                    questions.Add(item);
+                }
+
+                return questions;
+            }
+        }
+
+        private static string GetTextFromCell(Cell cell, SharedStringTablePart stringTable)
+        {
+            if (cell == null)
+            {
+                return null;
+            }
+
+            string cellText = cell.CellValue.Text;
+            if (cell.DataType.Value == CellValues.SharedString)
+            {
+                cellText = stringTable.SharedStringTable.ElementAt(int.Parse(cellText)).InnerText;
+            }
+            return cellText;
+        }
+
+        /// <summary>
+        /// Creates an Xlsx document from a list of questions and stores it in a stream
+        /// </summary>
+        /// <param name="questions">the list of questions</param>
+        /// <param name="stream">the target stream</param>
+        public static void XlsxFromQuestions(IList<AnswerItem> questions, Stream stream)
+        {
+            // Open the document for editing.
+            using (SpreadsheetDocument spreadSheet = SpreadsheetDocument.Create(stream, SpreadsheetDocumentType.Workbook, true))
+            {
+                // Add a WorkbookPart to the document.
+                var workbookpart = spreadSheet.AddWorkbookPart();
+                workbookpart.Workbook = new Workbook();
+
+                var worksheetPart = InsertWorksheet(workbookpart);
+                Worksheet worksheet = worksheetPart.Worksheet;
+
+                var sharedStringPart = workbookpart.AddNewPart<SharedStringTablePart>();
+
+                // If the part does not contain a SharedStringTable, create one.
+                if (sharedStringPart.SharedStringTable == null)
+                {
+                    sharedStringPart.SharedStringTable = new SharedStringTable();
+                }
+
+                var sharedStringTable = sharedStringPart.SharedStringTable;
+
+                SetCelText(worksheet, "A", 1, "Questions", sharedStringTable);
+                SetCelText(worksheet, "B", 1, "Answer", sharedStringTable);
+                SetCelText(worksheet, "C", 1, "Metadata", sharedStringTable);
+
+                for (int i = 0; i < questions.Count; i++)
+                {
+                    SetCelText(worksheet, "A", (uint)i + 2, questions[i].Question, sharedStringTable);
+                    SetCelText(worksheet, "B", (uint)i + 2, questions[i].Answer, sharedStringTable);
+                    SetCelText(worksheet, "C", (uint)i + 2, questions[i].Metadata, sharedStringTable);
+                }
+
+                // Save the new worksheet.
+                worksheetPart.Worksheet.Save();
+            }
+        }
+
+        private static WorksheetPart InsertWorksheet(WorkbookPart workbookPart)
+        {
+            // Add a new worksheet part to the workbook.
+            WorksheetPart newWorksheetPart = workbookPart.AddNewPart<WorksheetPart>();
+            newWorksheetPart.Worksheet = new Worksheet(new SheetData());
+            newWorksheetPart.Worksheet.Save();
+
+            Sheets sheets = workbookPart.Workbook.Sheets = new Sheets();
+            string relationshipId = workbookPart.GetIdOfPart(newWorksheetPart);
+
+            string sheetName = "FAQ Answers";
+
+            // Append the new worksheet and associate it with the workbook.
+            Sheet sheet = new Sheet() { Id = relationshipId, SheetId = 1, Name = sheetName };
+            sheets.Append(sheet);
+            workbookPart.Workbook.Save();
+
+            return newWorksheetPart;
+        }
+
+        /// <summary>
+        /// Sets the cell text, adding a new cell if necessary
+        /// </summary>
+        /// <param name="worksheet">the worksheet</param>
+        /// <param name="row">the row of the cell in the worksheet</param>
+        /// <param name="col">the column of the cell in the worksheet</param>
+        /// <param name="text">the text to set the cell value to</param>
+        /// <param name="shareStringTable">the shared string table</param>
+        private static void SetCelText(Worksheet worksheet, string row, uint col, string text, SharedStringTable shareStringTable)
+        {
+            // ensure the text is in the shared string table
+            int index = InsertSharedStringItem(text, shareStringTable);
+
+            // Insert cell A1 into the new worksheet.
+            Cell cell = InsertCellInWorksheet(row, col, worksheet);
+
+            // Set the value of cell A1.
+            cell.CellValue = new CellValue(index.ToString());
+            cell.DataType = new EnumValue<CellValues>(CellValues.SharedString);
+        }
+
+        /// <summary>
+        /// Given text and a SharedStringTablePart, creates a SharedStringItem with the specified text 
+        /// and inserts it into the SharedStringTablePart. If the item already exists, returns its index.
+        /// </summary>
+        /// <param name="text">The text to add to the shared string table</param>
+        /// <param name="sharedStringTable">the shared string table</param>
+        /// <returns>the index of the shared text</returns>
+        private static int InsertSharedStringItem(string text, SharedStringTable sharedStringTable)
+        {
+            int i = 0;
+
+            // Iterate through all the items in the SharedStringTable. If the text already exists, return its index.
+            foreach (SharedStringItem item in sharedStringTable.Elements<SharedStringItem>())
+            {
+                if (item.InnerText == text)
+                {
+                    return i;
+                }
+
+                i++;
+            }
+
+            // The text does not exist in the part. Create the SharedStringItem and return its index.
+            sharedStringTable.AppendChild(new SharedStringItem(new DocumentFormat.OpenXml.Spreadsheet.Text(text)));
+            sharedStringTable.Save();
+
+            return i;
+        }
+
+        private static Cell GetCell(Worksheet worksheet, string columnName, uint rowIndex)
+        {
+            SheetData sheetData = worksheet.GetFirstChild<SheetData>();
+
+            return sheetData?.Elements<Row>().Where(r => r.RowIndex == rowIndex).FirstOrDefault()
+                            ?.Elements<Cell>().Where(c => c.CellReference.Value == columnName + rowIndex).FirstOrDefault();
+        }
+
+        /// <summary>
+        /// Inserts a cell into the worksheet. If the cell already exists, returns it.
+        /// </summary>
+        /// <param name="columnName">the column in the worksheet to add the cell</param>
+        /// <param name="rowIndex">the row in the worksheet to add the cell</param>
+        /// <param name="worksheet">the worksheet part to add the cell</param>
+        /// <returns>the cel inserted or found</returns>
+        private static Cell InsertCellInWorksheet(string columnName, uint rowIndex, Worksheet worksheet)
+        {
+            SheetData sheetData = worksheet.GetFirstChild<SheetData>();
+            string cellReference = columnName + rowIndex;
+
+            // If the worksheet does not contain a row with the specified row index, insert one.
+            Row row;
+            if (sheetData.Elements<Row>().Where(r => r.RowIndex == rowIndex).Any())
+            {
+                row = sheetData.Elements<Row>().Where(r => r.RowIndex == rowIndex).First();
+            }
+            else
+            {
+                row = new Row() { RowIndex = rowIndex };
+                sheetData.Append(row);
+            }
+
+            // If there is not a cell with the specified column name, insert one.  
+            if (row.Elements<Cell>().Where(c => c.CellReference.Value == cellReference).Any())
+            {
+                return row.Elements<Cell>().Where(c => c.CellReference.Value == cellReference).First();
+            }
+            else
+            {
+                // Cells must be in sequential order according to CellReference. Determine where to insert the new cell.
+                Cell refCell = null;
+                foreach (Cell cell in row.Elements<Cell>())
+                {
+                    if (cell.CellReference.Value.Length == cellReference.Length)
+                    {
+                        if (string.Compare(cell.CellReference.Value, cellReference, true) > 0)
+                        {
+                            refCell = cell;
+                            break;
+                        }
+                    }
+                }
+
+                Cell newCell = new Cell() { CellReference = cellReference };
+                row.InsertBefore(newCell, refCell);
+
+                worksheet.Save();
+                return newCell;
+            }
+        }
+    }
+}

--- a/Source/Microsoft.Teams.Apps.FAQPlusPlus/Microsoft.Teams.Apps.FAQPlusPlus.csproj
+++ b/Source/Microsoft.Teams.Apps.FAQPlusPlus/Microsoft.Teams.Apps.FAQPlusPlus.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="AdaptiveCards" Version="1.2.4" />
+    <PackageReference Include="DocumentFormat.OpenXml" Version="2.12.3" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.14.0" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Knowledge.QnAMaker" Version="3.0.0-preview.1" />

--- a/Source/Microsoft.Teams.Apps.FAQPlusPlus/Microsoft.Teams.Apps.FAQPlusPlus.csproj
+++ b/Source/Microsoft.Teams.Apps.FAQPlusPlus/Microsoft.Teams.Apps.FAQPlusPlus.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <DocumentationFile>bin\Microsoft.Teams.Apps.FAQPlusPlus.xml</DocumentationFile>
     <LangVersion>latest</LangVersion>
+    <UserSecretsId>1afe81f2-7b30-4dc0-b0a3-263cb283f294</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- allow XLSX files to be uploaded and processed
  - 3 columns, (question, answer, metadata)
  - assumes a header row
- add code to allow debugging in emulator (assumes Teams 1:1 chat flow for emulator)