### PR TITLE
optionally upload faq bulk answers to blob storage instead of bot channel transfer

### DIFF
--- a/Source/Microsoft.Teams.Apps.FAQPlusPlus.Common/Models/Configuration/BotSettings.cs
+++ b/Source/Microsoft.Teams.Apps.FAQPlusPlus.Common/Models/Configuration/BotSettings.cs
@@ -28,5 +28,17 @@ namespace Microsoft.Teams.Apps.FAQPlusPlus.Common.Models.Configuration
         /// Gets or sets access tenant id string.
         /// </summary>
         public string TenantId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Azure storage connection string
+        /// </summary>
+        public string StorageConnectionString { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value indicating whether to use the normal
+        /// upload process for bulk QnA answers or to store them in blob storage
+        /// </summary>
+        public bool UseBlobStorageForBulkUploadResults = false;
+
     }
 }

--- a/Source/Microsoft.Teams.Apps.FAQPlusPlus/Microsoft.Teams.Apps.FAQPlusPlus.csproj
+++ b/Source/Microsoft.Teams.Apps.FAQPlusPlus/Microsoft.Teams.Apps.FAQPlusPlus.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="AdaptiveCards" Version="1.2.4" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.8.0" />
     <PackageReference Include="DocumentFormat.OpenXml" Version="2.12.3" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.14.0" />
     <PackageReference Include="Microsoft.AspNetCore.App" />

--- a/Source/Microsoft.Teams.Apps.FAQPlusPlus/Startup.cs
+++ b/Source/Microsoft.Teams.Apps.FAQPlusPlus/Startup.cs
@@ -99,7 +99,9 @@ namespace Microsoft.Teams.Apps.FAQPlusPlus
                 botSettings.AppBaseUri = this.Configuration["AppBaseUri"];
                 botSettings.MicrosoftAppId = this.Configuration["MicrosoftAppId"];
                 botSettings.TenantId = this.Configuration["TenantId"];
-            });
+                botSettings.StorageConnectionString = this.Configuration["StorageConnectionString"];
+                botSettings.UseBlobStorageForBulkUploadResults = Convert.ToBoolean(this.Configuration["UseBlobStorageForBulkUploadResults"]);
+           });
 
             services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
             services.AddSingleton<Common.Providers.IConfigurationDataProvider>(new Common.Providers.ConfigurationDataProvider(this.Configuration["StorageConnectionString"]));


### PR DESCRIPTION
In order to return bulk answered FAQs, the bots default behavior is to use Teams's file consent requests. This change provides an alternative which instead uploads the file to blob storage in a container named "bulkanswers" and then provides the user with a url to download the file (the url expires after an hour). It uses the existing blob storage connections string.

By default this behavior is disabled and can be enabled by setting the value "UseBlobStorageForBulkUploadResults" to "true" in the app settings